### PR TITLE
feat: move generic libraries into blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
   "workspaces": [
     "packages/firebase",
     "packages/form",
-    "packages/resolve"
+    "packages/resolve",
+    "packages/pluggable",
+    "packages/progress-bar",
+    "packages/queues"
   ],
   "homepage": "https://github.com/tekuasia/blocks#readme",
   "devDependencies": {

--- a/packages/pluggable/IPluggable.ts
+++ b/packages/pluggable/IPluggable.ts
@@ -1,0 +1,6 @@
+import IPlugin from './IPlugin'
+
+export default interface IPluggable {
+  plugins: IPlugin[]
+  use: (plugin: IPlugin) => any
+}

--- a/packages/pluggable/IPlugin.ts
+++ b/packages/pluggable/IPlugin.ts
@@ -1,0 +1,5 @@
+export default interface IPlugin {
+  id: string
+  dependencies: string[]
+  install: (dest: any) => Promise<any>
+}

--- a/packages/pluggable/LICENSE
+++ b/packages/pluggable/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 TekuAsia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pluggable/PluginLoader.ts
+++ b/packages/pluggable/PluginLoader.ts
@@ -1,0 +1,56 @@
+import EventEmitter from 'events'
+import IPlugin from './IPlugin'
+
+export default class PluginLoader extends EventEmitter {
+  private readonly loadedPlugins: string[] = []
+  private readonly loadingPlugins: string[] = []
+
+  constructor (private readonly plugins: IPlugin[], private readonly dest: any) {
+    super()
+  }
+
+  async loadPlugin (plugin: IPlugin): Promise<any> {
+    if (!this.isLoaded(plugin) && !this.isLoading(plugin) && this.areDependenciesLoaded(plugin)) {
+      this.loadingPlugins.push(plugin.id)
+
+      await plugin.install(this.dest)
+    }
+
+    return this.load()
+  }
+
+  isLoaded (plugin: IPlugin): boolean {
+    return this.loadedPlugins.includes(plugin.id)
+  }
+
+  isLoading (plugin: IPlugin): boolean {
+    return this.loadingPlugins.includes(plugin.id)
+  }
+
+  areDependenciesLoaded (plugin: IPlugin): boolean {
+    return !plugin.dependencies.some(d => !this.loadedPlugins.includes(d))
+  }
+
+  load (): void {
+    const pendingPlugins = this.plugins.filter(p => !this.isLoaded(p) && !this.isLoading(p))
+
+    if (pendingPlugins.length === 0) {
+      this.emit('done', this.loadedPlugins)
+    }
+
+    pendingPlugins.forEach(plugin => {
+      this.loadPlugin(plugin)
+        .then(() => {
+          this.loadedPlugins.push(plugin.id)
+          this.emit('plugin:loaded', plugin)
+        })
+        .catch(error => {
+          this.emit('plugin:error', {
+            error,
+            plugin
+          })
+          this.emit('error', error)
+        })
+    })
+  }
+}

--- a/packages/pluggable/README.md
+++ b/packages/pluggable/README.md
@@ -1,0 +1,3 @@
+@teku-blocks/pluggable
+=====
+Teku Pluggable is a form library used by TekuAsia's projects.

--- a/packages/pluggable/index.ts
+++ b/packages/pluggable/index.ts
@@ -6,8 +6,8 @@ export const load = async (plugins: IPlugin[], dest: IPluggable, onItem?: (plugi
   return await new Promise((resolve, reject) => {
     const loader = new PluginLoader(plugins, dest)
 
-    loader.on('done', loadedList => resolve(loadedList))
-    loader.on('error', err => reject(err))
+    loader.once('done', loadedList => resolve(loadedList))
+    loader.once('error', err => reject(err))
 
     if (onItem instanceof Function) {
       loader.on('plugin:loaded', onItem)
@@ -19,5 +19,5 @@ export const load = async (plugins: IPlugin[], dest: IPluggable, onItem?: (plugi
 }
 
 export { default as IPluggable } from './IPluggable'
-export { default as IPlugin } from './IPlugin'
-export { default as PluginLoader } from './PluginLoader'
+export type { default as IPlugin } from './IPlugin'
+export type { default as PluginLoader } from './PluginLoader'

--- a/packages/pluggable/index.ts
+++ b/packages/pluggable/index.ts
@@ -1,0 +1,23 @@
+import IPluggable from './IPluggable'
+import IPlugin from './IPlugin'
+import PluginLoader from './PluginLoader'
+
+export const load = async (plugins: IPlugin[], dest: IPluggable, onItem?: (plugin: any, error?: Error) => any): Promise<string[]> => {
+  return await new Promise((resolve, reject) => {
+    const loader = new PluginLoader(plugins, dest)
+
+    loader.on('done', loadedList => resolve(loadedList))
+    loader.on('error', err => reject(err))
+
+    if (onItem instanceof Function) {
+      loader.on('plugin:loaded', onItem)
+      loader.on('plugin:error', ({ plugin, error }) => onItem(plugin, error))
+    }
+
+    loader.load()
+  })
+}
+
+export { default as IPluggable } from './IPluggable'
+export { default as IPlugin } from './IPlugin'
+export { default as PluginLoader } from './PluginLoader'

--- a/packages/pluggable/package.json
+++ b/packages/pluggable/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@teku-blocks/pluggable",
+  "files": [
+    "README.md",
+    "LICENSE",
+    "index.js"
+  ],
+  "private": true,
+  "version": "1.0.0",
+  "description": "Teku's pluggable library",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tekuasia/blocks.git",
+    "directory": "packages/pluggable"
+  },
+  "keywords": [
+    "teku",
+    "building",
+    "blocks",
+    "pluggable"
+  ],
+  "author": {
+    "name": "Hung Luu",
+    "email": "hungluu2106@gmail.com"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/tekuasia/blocks/issues"
+  },
+  "homepage": "https://github.com/tekuasia/blocks#readme"
+}

--- a/packages/progress-bar/IProgressBarItem.ts
+++ b/packages/progress-bar/IProgressBarItem.ts
@@ -1,0 +1,6 @@
+export default interface IProgressBarItem {
+  total: number
+  current: number
+  title: string
+  step: string
+}

--- a/packages/progress-bar/LICENSE
+++ b/packages/progress-bar/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 TekuAsia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/progress-bar/ProgressBar.ts
+++ b/packages/progress-bar/ProgressBar.ts
@@ -1,5 +1,5 @@
 import { MultiBar, SingleBar } from 'cli-progress'
-import { times } from 'lodash'
+import { times, set, get } from 'lodash'
 import IProgressBarItem from './IProgressBarItem'
 
 /**
@@ -15,7 +15,8 @@ export default class ProgressBar {
     this.merge(data)
   }
 
-  merge (data: IProgressBarItem[]): void {
+  merge (newData: IProgressBarItem[]): void {
+    const data = newData.filter(Boolean)
     const addedCount = data.length - this.data.length
     const removedCount = this.data.length - data.length
 
@@ -37,6 +38,17 @@ export default class ProgressBar {
       bar.setTotal(total)
       bar.update(current, { title, ...other })
     })
+  }
+
+  update (path: string, value: string): void {
+    const currentValue = get(this.data, path) as string
+
+    if (currentValue !== undefined && currentValue !== value) {
+      const newData = this.data.slice()
+      set(newData, path, value)
+
+      this.merge(newData)
+    }
   }
 
   stop (): void {

--- a/packages/progress-bar/ProgressBar.ts
+++ b/packages/progress-bar/ProgressBar.ts
@@ -1,0 +1,45 @@
+import { MultiBar, SingleBar } from 'cli-progress'
+import { times } from 'lodash'
+import IProgressBarItem from './IProgressBarItem'
+
+/**
+ * Adapter to simplize implementation of CLI Progress
+ */
+export default class ProgressBar {
+  private readonly renderer: MultiBar
+  private readonly bars: SingleBar[] = []
+  data: IProgressBarItem[] = []
+
+  constructor (data: IProgressBarItem[] = [], options: any = {}) {
+    this.renderer = new MultiBar(options)
+    this.merge(data)
+  }
+
+  merge (data: IProgressBarItem[]): void {
+    const addedCount = data.length - this.data.length
+    const removedCount = this.data.length - data.length
+
+    this.data = data.slice()
+
+    // times detect values > 0
+    times(addedCount, () => this.bars.push(this.renderer.create(0, 0)))
+    times(removedCount, () => {
+      const lastBar = this.bars.pop()
+
+      if (lastBar instanceof SingleBar) {
+        this.renderer.remove(lastBar)
+      }
+    })
+
+    this.data.forEach(({ total, current, title, ...other }, idx) => {
+      const bar = this.bars[idx]
+
+      bar.setTotal(total)
+      bar.update(current, { title, ...other })
+    })
+  }
+
+  stop (): void {
+    this.renderer.stop()
+  }
+}

--- a/packages/progress-bar/README.md
+++ b/packages/progress-bar/README.md
@@ -1,0 +1,3 @@
+@teku-blocks/progress-bar
+=====
+Teku Progress Bar is a library used by TekuAsia's projects.

--- a/packages/progress-bar/index.ts
+++ b/packages/progress-bar/index.ts
@@ -1,0 +1,102 @@
+import { cyan, green, grey, red, yellow } from 'chalk'
+import { line, tick, cross } from 'figures'
+import { assign, map, max, padEnd, round } from 'lodash'
+import IProgressBarItem from './IProgressBarItem'
+import ProgressBar from './ProgressBar'
+
+const replaceTokens = (str: string, tokens: any): string => str.replace(/\{(\w+)\}/g, (_, key) => tokens[key] ?? key)
+
+export const createProgress = (data: IProgressBarItem[] = [], options: any = {}): ProgressBar => {
+  const progbar = new ProgressBar(data, assign({
+    barCompleteChar: '-',
+    barIncompleteChar: '·',
+    clearOnComplete: false,
+    stopOnComplete: true,
+    hideCursor: true,
+    barGlue: '>',
+    format: (options: any, params: any, payload: any): string => {
+      const {
+        barsize,
+        barCompleteString,
+        barIncompleteString
+      } = options
+
+      const isCompleted = params.value >= params.total
+
+      // bar
+      const barGlue: string = isCompleted ? barCompleteString[0] : options.barGlue ?? ''
+      const size = barsize - barGlue.length
+      const completeSize = Math.round(params.progress * size)
+      const completeString: string = barCompleteString.substr(0, completeSize)
+      const incompleteString: string = barIncompleteString.substr(0, size - completeSize)
+      const bar = `${completeString}${barGlue}${incompleteString}`
+
+      const eta: string = params.eta
+      let etaString
+
+      if (eta === 'NULL') {
+        etaString = grey('N/A')
+      } else if (eta === 'INF') {
+        etaString = yellow('∞')
+      } else {
+        etaString = cyan(`${eta}s`)
+      }
+
+      const longestTitle = max(map(progbar.data, i => i.title.length))
+      const title = padEnd(payload.title, longestTitle, ' ')
+      const step = payload.step
+
+      if (/^Load /.test(title)) {
+        if (isCompleted) {
+          return replaceTokens('{icon} {title} {step}', assign({}, payload, params, {
+            icon: green(tick),
+            title,
+            step
+          }))
+        } else if (params.value === -1) {
+          return replaceTokens('{icon} {title} {step}', assign({}, payload, params, {
+            icon: red(cross),
+            title,
+            step: red(step)
+          }))
+        } else {
+          return replaceTokens('{icon} {title} [{bar}] {value}/{total} {etaString}', assign({}, payload, params, {
+            icon: grey(line),
+            etaString,
+            title,
+            bar,
+            step
+          }))
+        }
+      } else {
+        if (isCompleted) {
+          return replaceTokens('  {icon} {title} {step}', assign({}, payload, params, {
+            icon: green(tick),
+            completeSeconds: round((params.stopTime.getTime() - params.startTime) / 1000, 1),
+            title,
+            step: grey.italic(step)
+          }))
+        } else if (params.value === -1) {
+          return replaceTokens('  {icon} {title} {step}', assign({}, payload, params, {
+            icon: red(cross),
+            title,
+            step: red(step)
+          }))
+        } else {
+          return replaceTokens('  {icon} {title} [{bar}] {value}/{total} {etaString} {step}', assign({}, payload, params, {
+            icon: grey(line),
+            etaString,
+            title,
+            bar,
+            step: grey.italic(step)
+          }))
+        }
+      }
+    }
+  }, options))
+
+  return progbar
+}
+
+export default ProgressBar
+export { default as IProgressBarItem } from './IProgressBarItem'

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@teku-blocks/progress-bar",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Teku's progress-bar library",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tekuasia/blocks.git",
+    "directory": "packages/progress-bar"
+  },
+  "keywords": [
+    "teku",
+    "building",
+    "blocks",
+    "progress-bar"
+  ],
+  "author": {
+    "name": "Hung Luu",
+    "email": "hungluu2106@gmail.com"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/tekuasia/blocks/issues"
+  },
+  "homepage": "https://github.com/tekuasia/blocks#readme",
+  "dependencies": {
+    "chalk": "^4.1.0",
+    "cli-progress": "^3.9.0",
+    "figures": "^3.2.0",
+    "lodash": "^4.17.21"
+  }
+}

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -29,5 +29,8 @@
     "cli-progress": "^3.9.0",
     "figures": "^3.2.0",
     "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@types/cli-progress": "^3.9.1"
   }
 }

--- a/packages/queues/ITask.ts
+++ b/packages/queues/ITask.ts
@@ -1,0 +1,14 @@
+import { TaskFn } from './TaskFn'
+import TaskStatus from './TaskStatus'
+
+export default interface ITask {
+  id: string
+  fn: TaskFn<Promise<any>>
+  status: TaskStatus
+  error?: Error
+
+  /**
+   * Ids of other tasks
+   */
+  dependencies: string[]
+}

--- a/packages/queues/LICENSE
+++ b/packages/queues/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 TekuAsia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/queues/README.md
+++ b/packages/queues/README.md
@@ -1,0 +1,3 @@
+@teku-blocks/queues
+=====
+Teku queues is a library used by TekuAsia's projects.

--- a/packages/queues/Task.ts
+++ b/packages/queues/Task.ts
@@ -1,0 +1,29 @@
+import ITask from './ITask'
+import { TaskFn } from './TaskFn'
+import TaskStatus from './TaskStatus'
+
+/**
+ * Queues Kit - Task
+ *
+ * @author Hung Luu <hungluu2106@gmail.com>
+ * @copyright TekuAsia (c) 2021
+ * @version 1.0
+ */
+export default class Task implements ITask {
+  status: TaskStatus = TaskStatus.PENDING
+  error?: Error
+  dependencies: string[] = []
+  fn: TaskFn<Promise<any>>
+
+  constructor (readonly id: string, private readonly process: TaskFn<any>, onDone?: (dependencies: ITask[]) => void) {
+    if (onDone instanceof Function) {
+      this.fn = async (dependencies: ITask[]) => await this.processAsync(dependencies).finally(() => onDone(dependencies))
+    } else {
+      this.fn = async (dependencies: ITask[]) => await this.processAsync(dependencies)
+    }
+  }
+
+  async processAsync (dependencies: ITask[]): Promise<any> {
+    return this.process(dependencies)
+  }
+}

--- a/packages/queues/TaskFn.ts
+++ b/packages/queues/TaskFn.ts
@@ -1,0 +1,3 @@
+import ITask from './ITask'
+
+export type TaskFn<T> = (dependencies: ITask[]) => T

--- a/packages/queues/TaskManager.ts
+++ b/packages/queues/TaskManager.ts
@@ -1,0 +1,89 @@
+import EventEmitter from 'events'
+
+import ITask from './ITask'
+import TaskStatus from './TaskStatus'
+
+/**
+ * Queues Kit - TaskManager
+ *
+ * Task Manager that handles tasks concurrently (based on concurrency setting)
+ * and allow adding more tasks during operation
+ *
+ * @author Hung Luu <hungluu2106@gmail.com>
+ * @copyright TekuAsia (c) 2021
+ * @version 1.0
+ */
+export default class TaskManager extends EventEmitter {
+  readonly tasks: ITask[] = []
+  protected readonly successfulTasks: string[] = []
+
+  constructor (readonly concurrency: number = 10) {
+    super()
+  }
+
+  addTask (task: ITask): void {
+    this.emit('task:add', task)
+    this.tasks.push(task)
+  }
+
+  async processTask (task: ITask): Promise<any> {
+    if (!this.shouldProcessTask(task)) {
+      return
+    }
+
+    task.status = TaskStatus.RUNNING
+    this.emit('task:start', task)
+
+    try {
+      const dependencies = this.tasks.filter(t => task.dependencies.includes(t.id))
+
+      await task.fn(dependencies)
+      this.successfulTasks.push(task.id)
+      this.emit('task:success', task)
+    } catch (err) {
+      task.error = err
+      this.emit('task:error', task)
+    } finally {
+      task.status = TaskStatus.DONE
+      this.emit('task:done', task)
+
+      this.processTasks()
+    }
+  }
+
+  processTasks (): this {
+    const pendingTasks = this.tasks.filter(task => task.status === TaskStatus.PENDING)
+
+    pendingTasks.forEach(task => {
+      this.processTask(task).catch(err => this.emit('error', err))
+    })
+
+    if (pendingTasks.length === 0 && !this.tasks.some(task => task.status === TaskStatus.RUNNING)) {
+      // No running or pending tasks so considered all completed
+      this.emit('done')
+    }
+
+    return this
+  }
+
+  getRunningCount (): number {
+    return this.tasks.filter(task => task.status === TaskStatus.RUNNING).length
+  }
+
+  private shouldProcessTask (task: ITask): boolean {
+    if (this.getRunningCount() >= this.concurrency) {
+      return false
+    }
+
+    if (task.status !== TaskStatus.PENDING) {
+      return false
+    }
+
+    const hasUncompletedDependencies = task.dependencies.some(id => !this.successfulTasks.includes(id))
+    if (hasUncompletedDependencies) {
+      return false
+    }
+
+    return true
+  }
+}

--- a/packages/queues/TaskStatus.ts
+++ b/packages/queues/TaskStatus.ts
@@ -1,0 +1,8 @@
+enum TaskStatus {
+  PENDING = 'pending',
+  RUNNING = 'running',
+  DONE = 'done',
+  CANCELLED = 'cancelled'
+}
+
+export default TaskStatus

--- a/packages/queues/index.ts
+++ b/packages/queues/index.ts
@@ -1,0 +1,5 @@
+export { default as ITask } from './ITask'
+export { default as Task } from './Task'
+export { default as TaskStatus } from './TaskStatus'
+export { default } from './TaskManager'
+export { TaskFn } from './TaskFn'

--- a/packages/queues/package.json
+++ b/packages/queues/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@teku-blocks/queues",
+  "files": [
+    "README.md",
+    "LICENSE",
+    "index.js"
+  ],
+  "private": true,
+  "version": "1.0.0",
+  "description": "Teku's queues library",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tekuasia/blocks.git",
+    "directory": "packages/queues"
+  },
+  "keywords": [
+    "teku",
+    "building",
+    "blocks",
+    "queues"
+  ],
+  "author": {
+    "name": "Hung Luu",
+    "email": "hungluu2106@gmail.com"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/tekuasia/blocks/issues"
+  },
+  "homepage": "https://github.com/tekuasia/blocks#readme"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "include": [
     "./packages/firebase",
     "./packages/form",
-    "./packages/resolve"
+    "./packages/resolve",
+    "./packages/pluggable",
+    "./packages/progress-bar",
+    "./packages/queues"
   ],
   "compilerOptions": {
     // "declaration": true,
@@ -20,13 +23,14 @@
     ],
     "strict": true,
     // "noEmit": true,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "esModuleInterop": true,
     "noUnusedLocals": false,
     "allowJs": true,
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+    "noImplicitAny": false
   },
   "exclude": [
     "node_modules"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,8 +29,7 @@
     "allowJs": true,
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
-    "noImplicitAny": false
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
   },
   "exclude": [
     "node_modules"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,10 @@ const getConfig = async () => {
     entry: {
       ...await expandEntries('packages/form'),
       ...await expandEntries('packages/firebase'),
-      ...await expandEntries('packages/resolve')
+      ...await expandEntries('packages/resolve'),
+      ...await expandEntries('packages/pluggable'),
+      ...await expandEntries('packages/progress-bar'),
+      ...await expandEntries('packages/queues')
       // TODO: Enable react components compilation after getting setup fixed
       // ...await expandEntries('packages/react/controls', '**/*.tsx')
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,13 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
+"@types/cli-progress@^3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.9.1.tgz#285e7fbdad6e7baf072d163ae1c3b23b7b219130"
+  integrity sha512-X/tKJv/GoYlCBS9wwJTLrVSxzIOI/Cj1cCatYOAAoQne3aT1QbHBptBS5+zLe2ToSljAijHU1N/ouBNFvZ2H/g==
+  dependencies:
+    "@types/node" "*"
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"
@@ -646,6 +653,14 @@ clean-webpack-plugin@^3.0.0:
     "@types/webpack" "^4.4.31"
     del "^4.1.1"
 
+cli-progress@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.9.0.tgz#25db83447deb812e62d05bac1af9aec5387ef3d4"
+  integrity sha512-g7rLWfhAo/7pF+a/STFH/xPyosaL1zgADhI0OM83hl3c7S43iGvJWEAV2QuDOnQ8i6EMBj/u4+NTd0d5L+4JfA==
+  dependencies:
+    colors "^1.1.2"
+    string-width "^4.2.0"
+
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
@@ -683,6 +698,11 @@ colorette@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+
+colors@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -1176,6 +1196,13 @@ fastq@^1.6.0:
   integrity sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
   dependencies:
     reusify "^1.0.4"
+
+figures@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
Fixes for #6 

#### This PR moves generic libraries into blocks:
 The list libraries:
- [x] `progress-bar`
- [x] `pluggable`
- [x] `queues`

